### PR TITLE
docs: Add R2 lifecycle configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,16 @@ Clear session data.
    wrangler r2 bucket create work-rs-files
    ```
 
-3. **Deploy to Cloudflare Workers:**
+3. **Configure R2 lifecycle rules (optional):**
+   ```bash
+   # Delete objects after 1 day (useful for temporary/test data)
+   wrangler r2 bucket lifecycle add work-rs-files "delete-after-1-day" --expire-days 1
+
+   # List all lifecycle rules
+   wrangler r2 bucket lifecycle list work-rs-files
+   ```
+
+4. **Deploy to Cloudflare Workers:**
    ```bash
    wrangler deploy
    ```


### PR DESCRIPTION
## Summary
Add documentation for configuring R2 bucket lifecycle rules using wrangler CLI.

## Changes
- Document how to add lifecycle rules to automatically delete objects after a specified time
- Include example command for the 1-day deletion rule that's currently configured
- Add command to list existing lifecycle rules

## Context
The R2 bucket `work-rs-files` now has a lifecycle rule configured to delete objects after 1 day, which is useful for temporary/test data. This PR documents how to set up and manage these rules.

## Test plan
- [x] Lifecycle rule successfully configured on the bucket
- [x] Documentation is clear and includes working commands

🤖 Generated with [Claude Code](https://claude.ai/code)