### PR TITLE
ci: Replace Codecov with Code Coverage Summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,18 @@ jobs:
     - name: Generate coverage
       run: cargo tarpaulin --verbose --out Xml
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5
+    - name: Code Coverage Summary
+      uses: irongut/CodeCoverageSummary@v1.3.0
       with:
-        files: ./cobertura.xml
-        fail_ci_if_error: false
+        filename: cobertura.xml
+        badge: true
+        format: markdown
+        thresholds: '60 80'
+        output: both
+
+    - name: Add Coverage PR Comment
+      uses: marocchino/sticky-pull-request-comment@v2
+      if: github.event_name == 'pull_request'
+      with:
+        recreate: true
+        path: code-coverage-results.md


### PR DESCRIPTION
## Summary
Replaces Codecov integration with the Code Coverage Summary GitHub Action, eliminating the need for an external account.

## Changes
- Remove Codecov action from CI workflow
- Add Code Coverage Summary action that runs entirely within GitHub
- Configure coverage badge generation
- Add sticky PR comments with coverage results (only on PRs)
- Set coverage thresholds: 60% minimum, 80% for healthy status

## Benefits
- No external service dependency
- No account/token management needed
- Coverage reports directly in GitHub
- Automatic PR comments with coverage details
- Built-in badge generation

## Testing
The new coverage reporting will be visible when this PR's CI runs.

🤖 Generated with [Claude Code](https://claude.ai/code)