### PR TITLE
feat: Add automated deployment to Cloudflare Workers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy to Cloudflare Workers
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
+      with:
+        targets: wasm32-unknown-unknown
+
+    - name: Cache cargo dependencies
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Install worker-build
+      run: |
+        if ! command -v worker-build &> /dev/null; then
+          cargo install worker-build
+        fi
+
+    - name: Build Worker
+      run: worker-build --release
+
+    - name: Deploy to Cloudflare Workers
+      uses: cloudflare/wrangler-action@2b7815c6fccae7ffc7b2e823ad72dd8e9b156995 # v3
+      with:
+        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ Clear session data.
 
 ## Deployment
 
+### Manual Deployment
+
 1. **Login to Cloudflare (first time only):**
    ```bash
    wrangler login
@@ -265,6 +267,32 @@ Clear session data.
    ```
 
    This will compile your Rust code to WebAssembly, bundle it, and deploy it to Cloudflare's edge network.
+
+### Automated Deployment (GitHub Actions)
+
+This repository includes a GitHub Actions workflow that automatically deploys to Cloudflare Workers on pushes to the `main` branch.
+
+#### Setup
+
+1. **Get your Cloudflare API token:**
+   - Go to [Cloudflare Dashboard](https://dash.cloudflare.com/profile/api-tokens)
+   - Click "Create Token"
+   - Use the "Edit Cloudflare Workers" template or create a custom token with:
+     - Account: `Cloudflare Workers Scripts:Edit`
+     - Zone: `Zone:Read` (if using custom domains)
+
+2. **Get your Cloudflare Account ID:**
+   - Go to any domain in your Cloudflare account
+   - The Account ID is in the right sidebar
+
+3. **Add secrets to your GitHub repository:**
+   - Go to your repository on GitHub
+   - Navigate to Settings → Secrets and variables → Actions
+   - Add the following secrets:
+     - `CLOUDFLARE_API_TOKEN`: Your API token from step 1
+     - `CLOUDFLARE_ACCOUNT_ID`: Your account ID from step 2
+
+Once configured, every push to the `main` branch will automatically build and deploy your Worker to Cloudflare.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automatic deployment on push to main
- Update README with deployment instructions and secret setup guide
- Use pinned action versions for security

## Changes
- Created `.github/workflows/deploy.yml` with deployment workflow
- Added comprehensive setup instructions to README
- Workflow includes caching, proper permissions, and secure action pinning

## Setup Required
After merging, repository secrets need to be configured:
1. `CLOUDFLARE_API_TOKEN` - API token with Workers edit permissions
2. `CLOUDFLARE_ACCOUNT_ID` - Cloudflare account ID

See the updated README for detailed setup instructions.

🤖 Generated with [Claude Code](https://claude.ai/code)