### PR TITLE
fix: Update wrangler-action to v3.14.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
       run: worker-build --release
 
     - name: Deploy to Cloudflare Workers
-      uses: cloudflare/wrangler-action@2b7815c6fccae7ffc7b2e823ad72dd8e9b156995 # v3
+      uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
Fixes deployment failure by updating to correct wrangler-action reference.

## Problem
The deployment workflow was failing with:
```
An action could not be found at the URI 'https://api.github.com/repos/cloudflare/wrangler-action/tarball/2b7815c6fccae7ffc7b2e823ad72dd8e9b156995'
```

## Solution
- Updated to use the correct SHA for v3.14.1: `da0e0dfe58b7a431659754fdf3f186c529afbe65`

This should fix the deployment workflow immediately.

🤖 Generated with [Claude Code](https://claude.ai/code)