### PR TITLE
fix: Remove conflicting worker-build installation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,26 +20,6 @@ jobs:
       with:
         targets: wasm32-unknown-unknown
 
-    - name: Cache cargo dependencies
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-    - name: Install worker-build
-      run: |
-        if ! command -v worker-build &> /dev/null; then
-          cargo install worker-build
-        fi
-
-    - name: Build Worker
-      run: worker-build --release
-
     - name: Deploy to Cloudflare Workers
       uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
       with:


### PR DESCRIPTION
## Summary
Fixes deployment failure caused by conflicting worker-build installations.

## Problem
The deployment was failing with:
```
error: binary `worker-build` already exists in destination
binary `worker-codegen` already exists in destination
Add --force to overwrite
```

## Root Cause
Both our workflow and wrangler's build command were trying to install worker-build, causing a conflict.

## Solution
- Removed manual worker-build installation from deploy workflow
- Removed the build step since wrangler handles it automatically
- Let wrangler manage the entire build process through the `build.command` in wrangler.toml

The wrangler.toml already has:
```toml
[build]
command = "cargo install -q worker-build && ~/.cargo/bin/worker-build --release"
```

So we don't need to pre-install it.

🤖 Generated with [Claude Code](https://claude.ai/code)