### PR TITLE
fix: Remove conflicting SQLite migration

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -28,4 +28,3 @@ bindings = [
   { name = "SESSION_OBJECT", class_name = "SessionObject" },
   { name = "FILE_MAPPING_OBJECT", class_name = "FileMappingObject" }
 ]
-

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -29,7 +29,8 @@ bindings = [
   { name = "FILE_MAPPING_OBJECT", class_name = "FileMappingObject" }
 ]
 
-# Migration for Durable Objects
-[[migrations]]
-tag = "v4"
-new_sqlite_classes = ["CounterObject", "SessionObject", "FileMappingObject"]
+# Migrations are commented out because the Durable Objects already exist
+# and cannot be migrated to SQLite after they have data
+# [[migrations]]
+# tag = "v4"
+# new_sqlite_classes = ["CounterObject", "SessionObject", "FileMappingObject"]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -29,8 +29,3 @@ bindings = [
   { name = "FILE_MAPPING_OBJECT", class_name = "FileMappingObject" }
 ]
 
-# Migrations are commented out because the Durable Objects already exist
-# and cannot be migrated to SQLite after they have data
-# [[migrations]]
-# tag = "v4"
-# new_sqlite_classes = ["CounterObject", "SessionObject", "FileMappingObject"]


### PR DESCRIPTION
## Summary
Fixes deployment failure by removing SQLite migration that conflicts with existing Durable Objects.

## Problem
Deployment was failing with:
```
Cannot apply new-sqlite-class migration to class 'CounterObject' 
that is already depended on by existing Durable Objects [code: 10074]
```

## Root Cause
The `new_sqlite_classes` migration attempts to convert existing Durable Objects to SQLite storage, but this cannot be done when:
1. The Durable Objects already exist in production
2. They already contain data/state
3. They are being actively used

## Solution
- Commented out the migration in wrangler.toml
- The existing Durable Objects will continue to work with their current storage
- New deployments will succeed without trying to migrate existing objects

## Note
If you need SQLite storage for new Durable Objects in the future, you would need to:
1. Create new classes with different names
2. Migrate data manually if needed
3. Or delete all existing objects first (data loss)

🤖 Generated with [Claude Code](https://claude.ai/code)